### PR TITLE
upgrade panic-itm because of build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 log = "0.4.1"
 aligned = "0.1.1"
-panic-itm = "0.2"
+panic-itm = "0.4"
 cortex-m-rt = "0.5.0"
 byteorder = { version = "1.2", default-features = false }
 cortex-m = { version = "0.5", features = ["const-fn", "inline-asm"] }


### PR DESCRIPTION
I git the following build errors:
```bash
cargo build --target=thumbv7em-none-eabihf                                                                                                                        18:06:46
    Updating crates.io index
   Compiling panic-itm v0.2.0
error[E0557]: feature has been removed
  --> /Users/uwe/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.2.0/src/lib.rs:33:12
   |
33 | #![feature(panic_implementation)]
   |            ^^^^^^^^^^^^^^^^^^^^
   |
note: subsumed by `#[panic_handler]`
  --> /Users/uwe/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.2.0/src/lib.rs:33:12
   |
33 | #![feature(panic_implementation)]
   |            ^^^^^^^^^^^^^^^^^^^^

error[E0658]: The attribute `panic_implementation` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
  --> /Users/uwe/.cargo/registry/src/github.com-1ecc6299db9ec823/panic-itm-0.2.0/src/lib.rs:44:3
   |
44 | #[panic_implementation]
   |   ^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(custom_attribute)] to the crate attributes to enable

error: aborting due to 2 previous errors

Some errors occurred: E0557, E0658.
For more information about an error, try `rustc --explain E0557`.
error: Could not compile `panic-itm`.
```
The upgrade of panic-itm fixes them